### PR TITLE
Add web interface docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 
 - [Experimental technology disclaimer](#experimental-technology-disclaimer)
 - [Quickstart](#quickstart)
+- [Web demo](#web-demo)
 - [Why Codex?](#why-codex)
 - [Security model & permissions](#security-model--permissions)
   - [Platform sandboxing details](#platform-sandboxing-details)
@@ -142,6 +143,20 @@ codex --approval-mode full-auto "create the fanciest todo-list app"
 That's it - Codex will scaffold a file, run it inside a sandbox, install any
 missing dependencies, and show you the live result. Approve the changes and
 they'll be committed to your working directory.
+
+## Web demo
+
+This repo also contains a very small web interface that communicates with the
+Codex agent via WebSockets. Start it with:
+
+```bash
+pnpm web
+```
+
+Then open <http://localhost:3000> in your browser and enter a prompt. Results
+appear in the page as they stream back from the agent.
+
+See [docs/web.md](docs/web.md) for a short guide.
 
 ---
 

--- a/docs/web.md
+++ b/docs/web.md
@@ -1,0 +1,23 @@
+# Web interface
+
+This repository includes a small demo web server that exposes the Codex agent over WebSockets.
+
+## Prerequisites
+
+- Node.js 22 or newer
+- `pnpm` (see [PNPM.md](../PNPM.md))
+
+## Usage
+
+1. Install dependencies and build the CLI (only needed once):
+   ```bash
+   pnpm install
+   pnpm build
+   ```
+2. Start the web server:
+   ```bash
+   pnpm web
+   ```
+3. Open <http://localhost:3000> in your browser and start sending prompts.
+
+The HTML UI lives in [`web/public/index.html`](../web/public/index.html). Feel free to tweak it for your needs.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test": "pnpm --filter @openai/codex run test",
     "lint": "pnpm --filter @openai/codex run lint",
     "lint:fix": "pnpm --filter @openai/codex run lint:fix",
-    "typecheck": "pnpm --filter @openai/codex run typecheck",
+  "typecheck": "pnpm --filter @openai/codex run typecheck",
+  "web": "node web/server.mjs",
     "changelog": "git-cliff --config cliff.toml --output CHANGELOG.ignore.md $LAST_RELEASE_TAG..HEAD",
     "prepare": "husky",
     "husky:add": "husky add"

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Codex Web</title>
+  <style>
+    body { font-family: sans-serif; padding: 20px; }
+    #messages { white-space: pre-wrap; border: 1px solid #ccc; padding: 10px; min-height: 200px; }
+  </style>
+</head>
+<body>
+  <div id="messages"></div>
+  <input id="prompt" type="text" style="width:80%" placeholder="Type your prompt" />
+  <button id="send">Send</button>
+  <script>
+    const ws = new WebSocket(`ws://${location.host}/ws`);
+    const messages = document.getElementById('messages');
+    ws.addEventListener('message', ev => {
+      const msg = JSON.parse(ev.data);
+      if (msg.type === 'loading') return;
+      messages.textContent += '\n' + JSON.stringify(msg, null, 2);
+    });
+    document.getElementById('send').addEventListener('click', () => {
+      const text = document.getElementById('prompt').value;
+      ws.send(JSON.stringify({ prompt: text }));
+    });
+  </script>
+</body>
+</html>

--- a/web/server.mjs
+++ b/web/server.mjs
@@ -1,0 +1,47 @@
+import 'ts-node/esm/transpile-only';
+import express from 'express';
+import { createServer } from 'http';
+import { WebSocketServer } from 'ws';
+import { loadConfig } from '../codex-cli/src/utils/config.ts';
+import { AgentLoop } from '../codex-cli/src/utils/agent/agent-loop.ts';
+import { AutoApprovalMode } from '../codex-cli/src/utils/auto-approval-mode.ts';
+import { ReviewDecision } from '../codex-cli/src/utils/agent/review.ts';
+import { createInputItem } from '../codex-cli/src/utils/input-utils.ts';
+
+const app = express();
+app.use(express.static(new URL('./public', import.meta.url).pathname));
+
+const server = createServer(app);
+const wss = new WebSocketServer({ server, path: '/ws' });
+
+wss.on('connection', (ws) => {
+  ws.on('message', async (data) => {
+    try {
+      const { prompt } = JSON.parse(data.toString());
+      if (!prompt) return;
+      const config = loadConfig();
+      const agent = new AgentLoop({
+        model: config.model,
+        provider: config.provider ?? 'openai',
+        instructions: config.instructions,
+        config,
+        approvalPolicy: AutoApprovalMode.FULL_AUTO,
+        additionalWritableRoots: [],
+        disableResponseStorage: config.disableResponseStorage,
+        onItem: (item) => ws.send(JSON.stringify(item)),
+        onLoading: (l) => ws.send(JSON.stringify({ type: 'loading', loading: l })),
+        getCommandConfirmation: async () => ({ review: ReviewDecision.YES }),
+        onLastResponseId: () => {},
+      });
+      const inputItem = await createInputItem(prompt, []);
+      await agent.run([inputItem]);
+    } catch (err) {
+      ws.send(JSON.stringify({ type: 'error', message: String(err) }));
+    }
+  });
+});
+
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => {
+  console.log(`Server running at http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- document how to start the browser-based demo
- link new docs from README and add to the table of contents
- adjust server to use ts-node loader

## Testing
- `pnpm test`
- `pnpm run lint`
- `pnpm run typecheck`
